### PR TITLE
Python 3.x compat, cleanup

### DIFF
--- a/check.py
+++ b/check.py
@@ -29,7 +29,6 @@ def check_pep8(srcdir):
     print(">>> Running pep8...")
     clean = True
     pep8.process_options([''])
-    pep8.options.repeat=True
     for pyfile in findpy(srcdir):
         if pep8.Checker(pyfile).check_all() != 0:
             clean = False

--- a/check.py
+++ b/check.py
@@ -39,12 +39,12 @@ def check_pep8(srcdir):
 def main():
     src = os.path.join(os.path.dirname(sys.argv[0]), 'stun')
     if not check_pyflakes(src):
-        print
+        print('')
         err = "ERROR: pyflakes failed on some source files\n"
         err += "ERROR: please fix the errors and re-run this script"
         print(err)
     elif not check_pep8(src):
-        print
+        print('')
         err = "ERROR: pep8 failed on some source files\n"
         err += "ERROR: please fix the errors and re-run this script"
         print(err)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README = open(os.path.join(src, 'README.rst')).read()
 
 setup(
     name='pystun',
-    version="0.0.4",
+    version="0.0.5",
     packages=find_packages(),
     scripts=['bin/pystun'],
     zip_safe=False,
@@ -23,5 +23,7 @@ setup(
         "Topic :: Internet",
         "Topic :: System :: Networking :: Firewalls",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3"
     ],
 )

--- a/stun/__init__.py
+++ b/stun/__init__.py
@@ -90,8 +90,8 @@ ChangedAddressError = "Meet an error, when do Test1 on Changed IP and Port"
 
 def _initialize():
     global dictValToArray, dictValToMsgType
-    dictValToArray = {v: k for k, v in dictAttrToVal.items()}
-    dictValToMsgType = {v: k for k, v in dictMsgTypeToVal.items()}
+    dictValToArray = dict((v, k) for k, v in dictAttrToVal.items())
+    dictValToMsgType = dict((v, k) for k, v in dictMsgTypeToVal.items())
 
 
 def gen_tran_id():
@@ -244,9 +244,9 @@ def get_ip_info(source_ip="0.0.0.0", source_port=54320, stun_host=None,
 
 def main():
     nat_type, external_ip, external_port = get_ip_info()
-    print("NAT Type: {}".format(nat_type))
-    print("External IP: {}".format(external_ip))
-    print("External Port: {}".format(external_port))
+    print("NAT Type: {0}".format(nat_type))
+    print("External IP: {0}".format(external_ip))
+    print("External Port: {0}".format(external_port))
 
 if __name__ == '__main__':
     main()

--- a/stun/cli.py
+++ b/stun/cli.py
@@ -1,4 +1,6 @@
-#coding=utf-8
+#!/usr/bin/env python
+# coding=utf-8
+
 import optparse
 
 import stun
@@ -26,9 +28,9 @@ def main():
                   stun_host=options.stun_host,
                   stun_port=options.stun_port)
     nat_type, external_ip, external_port = stun.get_ip_info(**kwargs)
-    print "NAT Type:", nat_type
-    print "External IP:", external_ip
-    print "External Port:", external_port
+    print("NAT Type: {}".format(nat_type))
+    print("External IP: {}".format(external_ip))
+    print("External Port: {}".format(external_port))
 
 if __name__ == '__main__':
     main()

--- a/stun/cli.py
+++ b/stun/cli.py
@@ -28,9 +28,9 @@ def main():
                   stun_host=options.stun_host,
                   stun_port=options.stun_port)
     nat_type, external_ip, external_port = stun.get_ip_info(**kwargs)
-    print("NAT Type: {}".format(nat_type))
-    print("External IP: {}".format(external_ip))
-    print("External Port: {}".format(external_port))
+    print("NAT Type: {0}".format(nat_type))
+    print("External IP: {0}".format(external_ip))
+    print("External Port: {0}".format(external_port))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
I updated the code to be Python 3-compatible; it should run under any 2.6+/3.2+.

I smoke-tested with 2.6, 2.7, 3.3, and pre-3.5 trunk with CPython, and 2.7 and 3.2 with PyPy 2.3.1.

Rather than try to fix all the mixed-str-and-bytes stuff caused by trying to work with hex strings instead of raw bytes, I changed it to use `struct.pack`/`unpack` everywhere. I believe I caught and fixed at least one bug along the way where a hex string was sent in place of the bytes it represented. But I wouldn't be too surprised if I also added at least one bug. Unfortunately, there doesn't seem to be a test suite, and I'm not sure how to stress-test it myself.

I also cleaned up the code so that it passes PEP8 (no point adding an automated PEP8 test to just ignore the warnings…), and updated `check.py` so that it works with PEP8 1.3 and later.
