### PR TITLE
Release fixes for 0.1 version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Changelog
 ---------
-0.0.5 (05/11/2014)
+0.1.0 (2014/11/07)
 ******************
 - Drop support for Python 2.6 and earlier.
 - Add a proper LICENSE file.
@@ -19,11 +19,11 @@ Changelog
 - Drop optparse in favour of argparse.
 - Update usage message in README.
 
-0.0.4 (14/10/2013)
+0.0.4 (2013/10/14)
 ******************
 - Stun: added functionality to pass the initial STUN server port explicitly
 
-0.0.3 (21/05/2013)
+0.0.3 (2013/05/21)
 ******************
 - Stun: fix UnboundLocalError in get_nat_type.
 - Stun: remove dead hosts from stun server list.

--- a/stun/cli.py
+++ b/stun/cli.py
@@ -48,8 +48,12 @@ def main():
             logging.basicConfig()
             stun.log.setLevel(logging.DEBUG)
 
-        kwargs = vars(options)
-        nat_type, external_ip, external_port = stun.get_ip_info(**kwargs)
+        nat_type, external_ip, external_port = stun.get_ip_info(
+            source_ip=options.source_ip,
+            source_port=options.source_port,
+            stun_host=options.stun_host,
+            stun_port=options.stun_port
+        )
         print('NAT Type:', nat_type)
         print('External IP:', external_ip)
         print('External Port:', external_port)


### PR DESCRIPTION
### Changelog
- Update `CHANGELOG` to reflect the release version. Change the date format to `YYYY/MM/DD`.
- Do not pass `debug` argument to `get_ip_info`.
