### PR TITLE
Remove global side effects to socket library

### DIFF
--- a/stun/__init__.py
+++ b/stun/__init__.py
@@ -245,8 +245,8 @@ def get_nat_type(s, source_ip, source_port, stun_host=None, stun_port=3478):
 
 def get_ip_info(source_ip="0.0.0.0", source_port=54320, stun_host=None,
                 stun_port=3478):
-    socket.setdefaulttimeout(2)
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.settimeout(2)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind((source_ip, source_port))
     nat_type, nat = get_nat_type(s, source_ip, source_port,


### PR DESCRIPTION
Previously the get_ip_info function used `socket.setdefaulttimeout` to
set the socket timeout for its query socket. This function sets the
default socket timeout globally, and thus caused side effects after this
function was called (in any library or code that uses sockets).

This change removes the previous setdefaulttimeout call in favor of
setting the timeout directly on the socket itself.
